### PR TITLE
You forgor to dispose it

### DIFF
--- a/Cyrup_Bootstrapper/Program.cs
+++ b/Cyrup_Bootstrapper/Program.cs
@@ -58,6 +58,7 @@ namespace Cyrup_Bootstrapper
             }
 
             Console.WriteLine("Starting...");
+            wc.Dispose();
             Process.Start($"{AppDomain.CurrentDomain.BaseDirectory}\\bin\\Release\\Cyrup_Rewrite.exe");
         }
     }


### PR DESCRIPTION
Also, using a using statement is better because it auto disposes but this works as well